### PR TITLE
simulate fib.s on ubuntu 18.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Assemble Test
       run: |
-        ninja -Cbuild test
+        ninja -Cbuild asmtest
 
     # FIXME: valgrind with clnag-14 seems like few problems exist.
     # https://github.com/google/sanitizers/issues/856

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.25)
+# cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.16)
 project(asmkheiv CXX)
 # FIXME: this seems bad...
-set (CMAKE_CXX_COMPILER /usr/bin/clang++ CACHE PATH "" FORCE)
+# set (CMAKE_CXX_COMPILER /usr/bin/clang++ CACHE PATH "" FORCE)
 
 set(CMAKE_CXX_FLAGS "-Wall -march=native -fPIC  ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_STANDARD 20)
@@ -45,14 +46,20 @@ add_subdirectory(lib)
 
 add_subdirectory(tools)
 
-
-
 include(FetchContent)
+
+if(${CMAKE_VERSION} VERSION_LESS "3.25")
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+else()
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
   DOWNLOAD_EXTRACT_TIMESTAMP true
 )
+endif()
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(lib)
 
 add_subdirectory(tools)
 
+enable_testing()
 include(FetchContent)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.25")
@@ -74,7 +75,7 @@ add_custom_target(unittests
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 
-add_custom_target(test
+add_custom_target(asmtest
   COMMAND make -C ../tests test
   DEPENDS asmkheiv simkheiv
 )

--- a/include/Debug.h
+++ b/include/Debug.h
@@ -16,7 +16,7 @@ void dumpInstVal(unsigned Val) {
 
   std::cerr << "\n";
   std::cerr << "Hex(LE): ";
-  for (int i = 0; i < sizeof(Val); ++i) {
+  for (unsigned long i = 0; i < sizeof(Val); ++i) {
     unsigned char byte = (Val >> (i * 8)) & 0xFF;
     std::cerr << std::hex << std::setw(2) << std::setfill('0')
               << static_cast<int>(byte) << ' ';
@@ -46,7 +46,7 @@ void debugInstOnAsm(const std::vector<std::string> Toks, unsigned Val) {
 
   std::cerr << "\n";
   std::cerr << "Hex(LE): ";
-  for (int i = 0; i < sizeof(Val); ++i) {
+  for (unsigned long i = 0; i < sizeof(Val); ++i) {
     unsigned char byte = (Val >> (i * 8)) & 0xFF;
     std::cerr << std::hex << std::setw(2) << std::setfill('0')
               << static_cast<int>(byte) << ' ';

--- a/include/Debug.h
+++ b/include/Debug.h
@@ -3,7 +3,28 @@
 #include <iomanip>
 #include <iostream>
 #include <vector>
-void debugInst(const std::vector<std::string> Toks, unsigned Val) {
+
+void dumpInstVal(unsigned Val) {
+
+  std::bitset<32> binaryValue(Val);
+  std::cerr << "Binary(BE): ";
+  for (int i = 0; i < 32; ++i) {
+    if (i == 7 || i == 12 || i == 17 || i == 20 || i == 25)
+      std::cerr << ' ';
+    std::cerr << ((binaryValue >> (31 - i)).to_ulong() & 1);
+  }
+
+  std::cerr << "\n";
+  std::cerr << "Hex(LE): ";
+  for (int i = 0; i < sizeof(Val); ++i) {
+    unsigned char byte = (Val >> (i * 8)) & 0xFF;
+    std::cerr << std::hex << std::setw(2) << std::setfill('0')
+              << static_cast<int>(byte) << ' ';
+  }
+  std::cerr << "\n\n";
+}
+
+void debugInstOnAsm(const std::vector<std::string> Toks, unsigned Val) {
 
   bool first = true;
   for (auto &s : Toks) {

--- a/include/Instructions.h
+++ b/include/Instructions.h
@@ -270,7 +270,7 @@ private:
   std::bitset<12> Imm;
 
 public:
-  /// This is expected to be used on asm.
+  /// Encoding.
   SInstruction(const ISBType &ST, const std::vector<std::string> &Toks)
       : ST(ST) {
 
@@ -340,6 +340,23 @@ public:
            (BT.getFunct3().to_ulong() << 12) | (((ImmU & M2) >> 1) << 8) |
            (((ImmU & M3) >> 11) << 7) | BT.getOpcode().to_ulong());
   }
+
+  BInstruction(const ISBType &BT, const unsigned Rs1, const unsigned Rs2,
+               const unsigned Imm)
+      : BT(BT), Rs1(Rs1), Rs2(Rs2), Imm(Imm) {
+    // FIXME: rename member as _XX?
+    unsigned M0 = 0b1000000000000;
+    unsigned M1 = 0b0011111100000;
+    unsigned M2 = 0b0000000011110;
+    unsigned M3 = 0b0100000000000;
+    std::cerr << "Mnemo: " << BT.getMnemo() << '\n';
+
+    setVal((((Imm & M0) >> 12) << 31) | (((Imm & M1) >> 5) << 25) |
+           (this->Rs2.to_ulong() << 20) | (this->Rs1.to_ulong() << 15) |
+           (BT.getFunct3().to_ulong() << 12) | (((Imm & M2) >> 1) << 8) |
+           (((Imm & M3) >> 11) << 7) | BT.getOpcode().to_ulong());
+  }
+
   void pprint(std::ostream &) override {
     std::cerr << BT.getMnemo() << "\n";
     std::cerr << "TODO: clean \n";
@@ -351,9 +368,7 @@ public:
     }
     assert(false && "unimplemented!");
   }
-  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override {
-    assert(false && "unimplemented!");
-  }
+  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override;
 };
 
 #endif

--- a/include/Instructions.h
+++ b/include/Instructions.h
@@ -232,7 +232,7 @@ private:
   std::bitset<21> Imm;
 
 public:
-  /// This is expected to be used on asm.
+  /// Encoding
   JInstruction(const UJType &JT, const std::vector<std::string> &Toks)
       : JT(JT) {
     unsigned M0 = 0b100000000000000000000;
@@ -246,6 +246,17 @@ public:
            (((ImmU & M2) >> 11) << 20) | (((ImmU & M3) >> 12) << 12) |
            (Rd.to_ulong() << 7) | JT.getOpcode().to_ulong());
   }
+
+  JInstruction(const UJType &JT, const unsigned Rd, const unsigned Imm)
+      : JT(JT), Rd(Rd), Imm(Imm) {
+    unsigned M0 = 0b100000000000000000000;
+    unsigned M1 = 0b000000000011111111110;
+    unsigned M2 = 0b000000000100000000000;
+    unsigned M3 = 0b011111111000000000000;
+    setVal((((Imm & M0) >> 20) << 31) | (((Imm & M1) >> 1) << 21) |
+           (((Imm & M2) >> 11) << 20) | (((Imm & M3) >> 12) << 12) | (Rd << 7) |
+           JT.getOpcode().to_ulong());
+  }
   void pprint(std::ostream &) override {
     std::cerr << JT.getMnemo() << "\n";
     std::cerr << "TODO: clean \n";
@@ -257,9 +268,7 @@ public:
     }
     assert(false && "unimplemented!");
   }
-  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override {
-    assert(false && "unimplemented!");
-  }
+  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override;
 };
 
 class SInstruction : public Instruction {

--- a/include/Instructions.h
+++ b/include/Instructions.h
@@ -162,7 +162,7 @@ private:
   std::bitset<5> Rd, Rs1, Rs2;
 
 public:
-  /// This is expected to be used on asm.
+  /// Encoding
   RInstruction(const RType &RT, const std::vector<std::string> &Toks) : RT(RT) {
     Rd = *findReg(Toks[1]);
     Rs1 = *findReg(Toks[2]);
@@ -171,6 +171,16 @@ public:
            (Rs1.to_ulong() << 15) | (RT.getFunct3().to_ulong() << 12) |
            (Rd.to_ulong() << 7) | RT.getOpcode().to_ulong());
   }
+
+  RInstruction(const RType &RT, const unsigned Rd, const unsigned Rs1,
+               const unsigned Rs2)
+      : RT(RT), Rd(Rd), Rs1(Rs1), Rs2(Rs2) {
+    // FIXME: rename member as _XX?
+    setVal((RT.getFunct7().to_ulong() << 25) | (this->Rs2.to_ulong() << 20) |
+           (this->Rs1.to_ulong() << 15) | (RT.getFunct3().to_ulong() << 12) |
+           (this->Rd.to_ulong() << 7) | RT.getOpcode().to_ulong());
+  }
+
   void pprint(std::ostream &) override {
     std::cerr << RT.getMnemo() << "\n";
     std::cerr << "TODO: clean \n";
@@ -182,9 +192,7 @@ public:
     }
     assert(false && "unimplemented!");
   }
-  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override {
-    assert(false && "unimplemented!");
-  }
+  void exec(Address &, GPRegisters &, Memory &, CustomRegisters &) override;
 };
 
 class UInstruction : public Instruction {
@@ -358,7 +366,6 @@ public:
     unsigned M1 = 0b0011111100000;
     unsigned M2 = 0b0000000011110;
     unsigned M3 = 0b0100000000000;
-    std::cerr << "Mnemo: " << BT.getMnemo() << '\n';
 
     setVal((((Imm & M0) >> 12) << 31) | (((Imm & M1) >> 5) << 25) |
            (this->Rs2.to_ulong() << 20) | (this->Rs1.to_ulong() << 15) |

--- a/include/Instructions.h
+++ b/include/Instructions.h
@@ -57,7 +57,7 @@ public:
 
   void dumpHex() {
     std::cerr << "Hex(LE): ";
-    for (int i = 0; i < sizeof(Val); ++i) {
+    for (long unsigned i = 0; i < sizeof(Val); ++i) {
       unsigned char byte = (Val >> (i * 8)) & 0xFF;
       std::cerr << std::hex << std::setw(2) << std::setfill('0')
                 << static_cast<int>(byte) << ' ';

--- a/include/Registers.h
+++ b/include/Registers.h
@@ -84,6 +84,7 @@ public:
       if (i % 4 == 3)
         std::cerr << '\n';
     }
+    std::cerr << '\n';
   }
 };
 

--- a/include/Registers.h
+++ b/include/Registers.h
@@ -1,6 +1,7 @@
 #ifndef REGISTERS_H
 #define REGISTERS_H
 
+#include "Simulator/Memory.h"
 #include <bitset>
 #include <cassert>
 #include <cstdint>
@@ -39,13 +40,22 @@ public:
   GPRegisters(const GPRegisters &) = delete;
   GPRegisters &operator=(const GPRegisters &) = delete;
 
-  GPRegisters() : Regs{0} {}
+  GPRegisters() : Regs{0} {
+    // The stack pointer is set in the default maximum mamory size + the start
+    // address of dram.
+    Regs[2] = DRAM_BASE + DRAM_SIZE;
+  }
   GPRegisters(std::initializer_list<std::pair<unsigned, Reg>> init_list)
       : Regs{0} {
     for (const auto &p : init_list) {
       assert(p.first < RegNum && "Register index out of bounds.");
+      assert(p.first != 2 &&
+             "The stack pointer sp = x2 is set for end of the dram.");
       Regs[p.first] = p.second;
     }
+    // The stack pointer is set in the default maximum mamory size + the start
+    // address of dram.
+    Regs[2] = DRAM_BASE + DRAM_SIZE;
   }
   Reg &operator[](unsigned index) {
     assert(index < RegNum && "Index out of bounds");

--- a/include/Simulator/Memory.h
+++ b/include/Simulator/Memory.h
@@ -1,11 +1,36 @@
 #ifndef MEMORY_H
 #define MEMORY_H
+#include <cstdint>
+#include <vector>
+
+// to avoid sanitizer overhead hell.
+#ifdef DEBUG
+// 1 MiB
+// const std::uint64_t DRAM_SIZE = 1 << 20;
+// 1 KiB
+const std::uint64_t DRAM_SIZE = 1 << 10;
+#else
+// 1 GiB
+const std::uint64_t DRAM_SIZE = 1 << 30;
+#endif
+
+using Address = std::uint64_t;
+const Address DRAM_BASE = 0x8000;
+
+using Byte = std::uint8_t;
+using Word = std::uint32_t;
+
 class Memory {
 private:
+  std::vector<Byte> DRAM;
+
 public:
   Memory(const Memory &) = delete;
   Memory &operator=(const Memory &) = delete;
 
-  Memory() {}
+  Memory() : DRAM(DRAM_SIZE, 0) {}
+
+  void writeWord(Address Ad, Word Val);
+  Word readWord(Address Ad);
 };
 #endif

--- a/include/Simulator/Simulator.h
+++ b/include/Simulator/Simulator.h
@@ -171,6 +171,14 @@ public:
           break;
         }
         break;
+      case 0b1101111: // jal
+        // imm[20|10:1|11|19:12] = inst[31|30:21|20|19:12]
+        PCInstMap.insert(
+            {P, std::make_unique<JInstruction>(
+                    JTypeKinds.find("jal")->second, Rd,
+                    ((InstVal & 0x80000000) >> 11) | (InstVal & 0xff000) |
+                        ((InstVal >> 9) & 0x800) | ((InstVal >> 20) & 0x7fe))});
+        break;
       default:
         assert(false && "unimplemented!");
         break;

--- a/include/Simulator/Simulator.h
+++ b/include/Simulator/Simulator.h
@@ -246,9 +246,13 @@ public:
   void execFromDRAMBASE() {
     PC = DRAM_BASE;
     while (auto &I = PCInstMap[PC]) {
-      // I->pprint(std::cerr);
-      dumpGPRegs();
       I->exec(PC, GPRegs, M, CRegs);
+#ifdef DEBUG
+      std::cerr << "Inst:\n";
+      I->pprint(std::cerr);
+      std::cerr << "Regs after:\n";
+      dumpGPRegs();
+#endif
       // TODO: dump instruction detail.
     }
     std::cerr << "stop on no instraction address\n";

--- a/include/Simulator/Simulator.h
+++ b/include/Simulator/Simulator.h
@@ -15,6 +15,8 @@ private:
   CPU C;
   Memory M;
   unsigned CodeSize;
+  Address PC;
+  // FIXME: byref?
   GPRegisters GPRegs;
   CustomRegisters CRegs;
   std::map<Address, std::unique_ptr<Instruction>> PCInstMap;
@@ -23,9 +25,10 @@ public:
   Simulator(const Simulator &) = delete;
   Simulator &operator=(const Simulator &) = delete;
 
-  Simulator(std::istream &is) {
+  Simulator(std::istream &is) : PC(DRAM_BASE) {
     // TODO: parse per 2 bytes for compressed instructions
     char Buff[4];
+    // starts from DRAM_BASE
     Address P = DRAM_BASE;
     while (is.read(Buff, 4)) {
       unsigned InstVal = *(reinterpret_cast<unsigned *>(Buff));
@@ -138,14 +141,16 @@ public:
   }
   GPRegisters &getGPRegs() { return GPRegs; }
 
-  void exec() {
-    Address PC = DRAM_BASE;
+  void execFromDRAMBASE() {
+    PC = DRAM_BASE;
     while (auto &I = PCInstMap[PC]) {
       I->exec(PC, GPRegs, M, CRegs);
     }
+    std::cerr << "stop on no instraction address\n";
   }
 
   void dumpGPRegs() { GPRegs.dump(); }
+  Address &getPC() { return PC; }
 };
 
 #endif

--- a/include/Simulator/Simulator.h
+++ b/include/Simulator/Simulator.h
@@ -14,9 +14,10 @@ class Simulator {
 private:
   CPU C;
   Memory M;
+  unsigned CodeSize;
   GPRegisters GPRegs;
   CustomRegisters CRegs;
-  std::vector<std::unique_ptr<Instruction>> Is;
+  std::map<Address, std::unique_ptr<Instruction>> PCInstMap;
 
 public:
   Simulator(const Simulator &) = delete;
@@ -25,8 +26,11 @@ public:
   Simulator(std::istream &is) {
     // TODO: parse per 2 bytes for compressed instructions
     char Buff[4];
+    Address P = DRAM_BASE;
     while (is.read(Buff, 4)) {
       unsigned InstVal = *(reinterpret_cast<unsigned *>(Buff));
+      // Raw inst
+      M.writeWord(P, InstVal);
       // TODO: separate this as Decoder
       unsigned Opcode = InstVal & 0x0000007f;
       unsigned Rd = (InstVal & 0x00000f80) >> 7;
@@ -35,71 +39,108 @@ public:
       unsigned Funct3 = (InstVal & 0x00007000) >> 12;
       unsigned Funct7 = (InstVal & 0xfe000000) >> 25;
 
+      // FIXME: enough to set just mnemonic? & mask for srai would be another
+      // time
       switch (Opcode) {
       case 0b0010011:
-        switch (Funct3) {
+        switch (unsigned Imm = InstVal >> 20; Funct3) {
         case 0b000: // addi rd, rs1, imm
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("addi")->second, Rd, Rs1, InstVal >> 20));
+          PCInstMap.insert(
+              {P, std::make_unique<IInstruction>(
+                      ITypeKinds.find("addi")->second, Rd, Rs1, Imm)});
           break;
         case 0b010: // slti rd, rs1, imm
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("slti")->second, Rd, Rs1, InstVal >> 20));
+          PCInstMap.insert(
+              {P, std::make_unique<IInstruction>(
+                      ITypeKinds.find("slti")->second, Rd, Rs1, Imm)});
           break;
         case 0b011: // sltiu rd, rs1, imm
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("sltiu")->second, Rd, Rs1, InstVal >> 20));
+          PCInstMap.insert(
+              {P, std::make_unique<IInstruction>(
+                      ITypeKinds.find("sltiu")->second, Rd, Rs1, Imm)});
           break;
         case 0b100: // xori
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("xori")->second, Rd, Rs1, InstVal >> 20));
+          PCInstMap.insert(
+              {P, std::make_unique<IInstruction>(
+                      ITypeKinds.find("xori")->second, Rd, Rs1, Imm)});
           break;
         case 0b110: // ori
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("ori")->second, Rd, Rs1, InstVal >> 20));
+          assert(false && "unimplemented!");
           break;
         case 0b111: // andi
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("andi")->second, Rd, Rs1, InstVal >> 20));
+          assert(false && "unimplemented!");
           break;
         case 0b001: // slli
-          Is.push_back(std::make_unique<IInstruction>(
-              ITypeKinds.find("slli")->second, Rd, Rs1, InstVal >> 20));
+          assert(false && "unimplemented!");
           break;
         case 0b101:
           if (Funct7 == 0) // srli
                            // this will be 6 bit for RV64I
-            Is.push_back(std::make_unique<IInstruction>(
-                ITypeKinds.find("srli")->second, Rd, Rs1,
-                (InstVal >> 20) & 0b11111));
+            // Is.push_back(std::make_unique<IInstruction>(
+            //     ITypeKinds.find("srli")->second, Rd, Rs1,
+            //     (InstVal >> 20) & 0b11111));
+            assert(false && "unimplemented!");
           else // srai
-            Is.push_back(std::make_unique<IInstruction>(
-                ITypeKinds.find("srai")->second, Rd, Rs1,
-                (InstVal >> 20) & 0b11111));
+            // Is.push_back(std::make_unique<IInstruction>(
+            //     ITypeKinds.find("srai")->second, Rd, Rs1,
+            //     (InstVal >> 20) & 0b11111));
+            assert(false && "unimplemented!");
           break;
         default:
           assert(false && "unimplemented!");
           break;
         }
         break;
-      case 0b1100111:
-        assert(false && "unimplemented!");
+      case 0b1100111: // jalr
+        PCInstMap.insert(
+            {P, std::make_unique<IInstruction>(ITypeKinds.find("jalr")->second,
+                                               Rd, Rs1, InstVal >> 20)});
         break;
       case 0b0000011:
-        assert(false && "unimplemented!");
+        switch (unsigned Imm = InstVal >> 20; Funct3) {
+        // TODO: other load insts
+        case 0b010: // lw rd ,offset(rs1)
+          PCInstMap.insert(
+              {P, std::make_unique<IInstruction>(ITypeKinds.find("lw")->second,
+                                                 Rd, Rs1, Imm)});
+          break;
+        default:
+          assert(false && "unimplemented!");
+          break;
+        }
+        break;
+      case 0b0010111: // auipc
+        PCInstMap.insert(
+            {P, std::make_unique<UInstruction>(UTypeKinds.find("auipc")->second,
+                                               Rd, InstVal & 0xfffff000)});
+        break;
+      case 0b0100011:
+        switch (unsigned Offset =
+                    (InstVal & 0xfe000000) >> 20 | ((InstVal >> 7) & 0x1f);
+                Funct3) {
+        case 0b010: // sw
+          PCInstMap.insert(
+              {P, std::make_unique<SInstruction>(STypeKinds.find("sw")->second,
+                                                 Rs1, Rs2, Offset)});
+          break;
+        default:
+          assert(false && "unimplemented!");
+          break;
+        }
         break;
       default:
         assert(false && "unimplemented!");
         break;
       }
+      P += 4;
+      CodeSize += 4;
     }
-    std::cerr << '\n';
   }
   GPRegisters &getGPRegs() { return GPRegs; }
 
   void exec() {
-    unsigned PC = 0;
-    for (const auto &I : Is) {
+    Address PC = DRAM_BASE;
+    while (auto &I = PCInstMap[PC]) {
       I->exec(PC, GPRegs, M, CRegs);
     }
   }

--- a/lib/BinaryEmitter.cpp
+++ b/lib/BinaryEmitter.cpp
@@ -55,7 +55,7 @@ void BinaryEmitter::emitBinary(std::ostream &os) {
 
     // TODO: create DEBUGEXPR MACRO to shorten this
 #ifdef DEBUG
-      debugInst(Toks, InstT->getVal());
+    debugInstOnAsm(Toks, InstT->getVal());
 #endif
     InstT->emitBinary(os);
     InstT.reset();

--- a/lib/Instructions.cpp
+++ b/lib/Instructions.cpp
@@ -1,45 +1,81 @@
 #include "Instructions.h"
-void IInstruction::exec(PC &P, GPRegisters &GPRegs, Memory &M,
+void IInstruction::exec(Address &P, GPRegisters &GPRegs, Memory &M,
                         CustomRegisters &) {
   std::string Mnemo = IT.getMnemo();
   int ImmI = signExtend(Imm);
-  if (Mnemo == "addi")
+  if (Mnemo == "addi") {
     GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] + ImmI;
-  else if (Mnemo == "slti")
+    P += 4;
+  } else if (Mnemo == "slti") {
     GPRegs[Rd.to_ulong()] = (signed)GPRegs[Rs1.to_ulong()] < ImmI;
-  else if (Mnemo == "sltiu")
+    P += 4;
+  } else if (Mnemo == "sltiu") {
     GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()] < ImmI;
-  else if (Mnemo == "xori")
-    GPRegs[Rd.to_ulong()] =
-        (unsigned)GPRegs[Rs1.to_ulong()] ^ ImmI; // FIXME: sext?
-  else if (Mnemo == "ori")
+    P += 4;
+  } else if (Mnemo == "xori") {
+    GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()] ^ ImmI;
+    P += 4;
+  } else if (Mnemo == "ori") {
     GPRegs[Rd.to_ulong()] =
         (unsigned)GPRegs[Rs1.to_ulong()] | ImmI; // FIXME: sext?
-  else if (Mnemo == "andi")
+    P += 4;
+  } else if (Mnemo == "andi") {
     GPRegs[Rd.to_ulong()] =
         (unsigned)GPRegs[Rs1.to_ulong()] & ImmI; // FIXME: sext?
-  else if (Mnemo == "jalr")
-    assert(false && "unimplemented!");
-  else if (Mnemo == "lb")
+    P += 4;
+  } else if (Mnemo == "jalr") {
+    // FIXME: should addresss calculation be wrapped?
+    GPRegs[Rd.to_ulong()] = P + 4;
+    P = (GPRegs[Rs1.to_ulong()] + ImmI) & ~1;
+  } else if (Mnemo == "lb")
     assert(false && "unimplemented!");
   else if (Mnemo == "lh")
     assert(false && "unimplemented!");
-  else if (Mnemo == "lw")
-    assert(false && "unimplemented!");
-  else if (Mnemo == "lbu")
+  else if (Mnemo == "lw") {
+    Word V = M.readWord(GPRegs[Rs1.to_ulong()] + ImmI);
+    GPRegs[Rd.to_ulong()] = V;
+    P += 4;
+  } else if (Mnemo == "lbu")
     assert(false && "unimplemented!");
   else if (Mnemo == "lhu")
     assert(false && "unimplemented!");
   // FIXME: shamt
-  else if (Mnemo == "slli")
+  else if (Mnemo == "slli") {
     GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()]
                             << Imm.to_ulong(); // FIXME: sext?
-  else if (Mnemo == "srli")
+    P += 4;
+  } else if (Mnemo == "srli") {
     GPRegs[Rd.to_ulong()] =
         (unsigned)GPRegs[Rs1.to_ulong()] >> Imm.to_ulong(); // FIXME: sext?
-  else if (Mnemo == "srai")
+    P += 4;
+  } else if (Mnemo == "srai") {
     GPRegs[Rd.to_ulong()] =
         (signed)GPRegs[Rs1.to_ulong()] >> Imm.to_ulong(); // FIXME: sext?
-  else
+    P += 4;
+  } else
+    assert(false && "unimplemented! or not exist");
+}
+void UInstruction::exec(Address &P, GPRegisters &GPRegs, Memory &M,
+                        CustomRegisters &) {
+  std::string Mnemo = UT.getMnemo();
+  int ImmI = signExtend(Imm);
+  if (Mnemo == "auipc") {
+    GPRegs[Rd.to_ulong()] = P + (ImmI & 0xfffff000);
+    P += 4;
+  } else
+    assert(false && "unimplemented! or not exist");
+}
+
+void SInstruction::exec(Address &P, GPRegisters &GPRegs, Memory &M,
+                        CustomRegisters &) {
+  std::string Mnemo = ST.getMnemo();
+
+  int ImmI = signExtend(Imm);
+  if (Mnemo == "sw") {
+    // FIXME: wrap?
+    Address Ad = GPRegs[Rs1.to_ulong()] + ImmI;
+    M.writeWord(Ad, GPRegs[Rs2.to_ulong()]);
+    P += 4;
+  } else
     assert(false && "unimplemented! or not exist");
 }

--- a/lib/Instructions.cpp
+++ b/lib/Instructions.cpp
@@ -55,6 +55,51 @@ void IInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
   } else
     assert(false && "unimplemented! or not exist");
 }
+
+void RInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
+                        CustomRegisters &) {
+  std::string Mnemo = RT.getMnemo();
+  if (Mnemo == "add") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] + GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "sub") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] - GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "sll") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()]
+                            << (GPRegs[Rs2.to_ulong()] & 0b11111);
+    PC += 4;
+  } else if (Mnemo == "slt") {
+    GPRegs[Rd.to_ulong()] =
+        (signed)GPRegs[Rs1.to_ulong()] < (signed)GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "sltu") {
+    GPRegs[Rd.to_ulong()] =
+        (unsigned)GPRegs[Rs1.to_ulong()] < (unsigned)GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "xor") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] ^ GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "srl") {
+    GPRegs[Rd.to_ulong()] =
+        (unsigned)GPRegs[Rs1.to_ulong()] >> (GPRegs[Rs2.to_ulong()] & 0b11111);
+    PC += 4;
+  } else if (Mnemo == "sra") {
+    GPRegs[Rd.to_ulong()] = (signed)GPRegs[Rs1.to_ulong()] >>
+                            (signed)(GPRegs[Rs2.to_ulong()] & 0b11111);
+    PC += 4;
+  } else if (Mnemo == "or") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] | GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  } else if (Mnemo == "and") {
+    GPRegs[Rd.to_ulong()] = GPRegs[Rs1.to_ulong()] & GPRegs[Rs2.to_ulong()];
+    PC += 4;
+  }
+
+  else
+    assert(false && "unimplemented! or not exist");
+}
+
 void UInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
                         CustomRegisters &) {
   std::string Mnemo = UT.getMnemo();

--- a/lib/Instructions.cpp
+++ b/lib/Instructions.cpp
@@ -10,7 +10,7 @@ void IInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
     GPRegs[Rd.to_ulong()] = (signed)GPRegs[Rs1.to_ulong()] < ImmI;
     PC += 4;
   } else if (Mnemo == "sltiu") {
-    GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()] < ImmI;
+    GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()] < (unsigned)ImmI;
     PC += 4;
   } else if (Mnemo == "xori") {
     GPRegs[Rd.to_ulong()] = (unsigned)GPRegs[Rs1.to_ulong()] ^ ImmI;

--- a/lib/Instructions.cpp
+++ b/lib/Instructions.cpp
@@ -123,3 +123,14 @@ void BInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
   } else
     assert(false && "unimplemented! or not exist");
 }
+
+void JInstruction::exec(Address &PC, GPRegisters &GPRegs, Memory &M,
+                        CustomRegisters &) {
+  std::string Mnemo = JT.getMnemo();
+  int ImmI = signExtend(Imm);
+  if (Mnemo == "jal") {
+    GPRegs[Rd.to_ulong()] = PC + 4;
+    PC += ImmI;
+  } else
+    assert(false && "unimplemented! or not exist");
+}

--- a/lib/Memory.cpp
+++ b/lib/Memory.cpp
@@ -1,0 +1,18 @@
+#include "Simulator/Memory.h"
+#include <cassert>
+#include <iostream>
+
+void Memory::writeWord(Address Ad, Word Val) {
+  Address DRAM_Ad = Ad - DRAM_BASE;
+  DRAM[DRAM_Ad] = Val & 0xff;
+  DRAM[DRAM_Ad + 1] = (Val >> 8) & 0xff;
+  DRAM[DRAM_Ad + 2] = (Val >> 16) & 0xff;
+  DRAM[DRAM_Ad + 3] = (Val >> 24) & 0xff;
+}
+
+Word Memory::readWord(Address Ad) {
+  Address DRAM_Ad = Ad - DRAM_BASE;
+  Word Val = DRAM[DRAM_Ad] + (DRAM[DRAM_Ad + 1] << 8) +
+             (DRAM[DRAM_Ad + 2] << 16) + (DRAM[DRAM_Ad + 3] << 24);
+  return Val;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,11 +5,11 @@ CLANG_BIN_FILES := $(patsubst %.s, %-clang.bin, $(ASSEMBLY_FILES))
 OBJ_FILES := $(patsubst %.s, %.o, $(ASSEMBLY_FILES))
 BIN_FILES := $(patsubst %.s, %.bin, $(ASSEMBLY_FILES))
 
-.PHONY: all clean test
+.PHONY: gen clean test
 
-all: $(CLANG_BIN_FILES) $(BIN_FILES)
+gen: $(CLANG_BIN_FILES) $(BIN_FILES)
 
-test: all
+test: gen
 	@for file in $(ASSEMBLY_FILES); do \
 		echo "Comparing $$file output..."; \
 		if ! cmp -s $$(basename $$file .s)-clang.bin $$(basename $$file .s).bin; then \
@@ -18,15 +18,6 @@ test: all
 		fi; \
 	done
 	rm -f $(BIN_FILES) $(OBJ_FILES) $(CLANG_BIN_FILES)
-
-gen: all
-	@for file in $(ASSEMBLY_FILES); do \
-		echo "Comparing $$file output..."; \
-		if ! cmp -s $$(basename $$file .s)-clang.bin $$(basename $$file .s).bin; then \
-			echo "binary differ for $$file"; \
-			diff -y <(hexdump $$(basename $$file .s)-clang.bin) <(hexdump $$(basename $$file .s).bin); \
-		fi; \
-	done
 
 %-clang.bin: %.o
 	llvm-objcopy -O binary $< $@

--- a/tests/fib0.s.tmp
+++ b/tests/fib0.s.tmp
@@ -1,0 +1,53 @@
+	.file	"fib.c"
+	.option nopic
+	.text
+	.align	2
+	.globl	fib
+	.type	fib, @function
+fib:
+	addi	sp,sp,-32
+	sw	ra,28(sp)
+	sw	s0,24(sp)
+	sw	s1,20(sp)
+	addi	s0,sp,32
+	sw	a0,-20(s0)
+	lw	a4,-20(s0)
+	li	a5,1
+	bgt	a4,a5,.L2
+	li	a5,1
+	j	.L3
+.L2:
+	lw	a5,-20(s0)
+	addi	a5,a5,-1
+	mv	a0,a5
+	call	fib
+	mv	s1,a0
+	lw	a5,-20(s0)
+	addi	a5,a5,-2
+	mv	a0,a5
+	call	fib
+	mv	a5,a0
+	add	a5,s1,a5
+.L3:
+	mv	a0,a5
+	lw	ra,28(sp)
+	lw	s0,24(sp)
+	lw	s1,20(sp)
+	addi	sp,sp,32
+	jr	ra
+	.size	fib, .-fib
+	.align	2
+	.globl	main
+	.type	main, @function
+main:
+	addi	sp,sp,-16
+	sw	ra,12(sp)
+	sw	s0,8(sp)
+	addi	s0,sp,16
+	li	a0,10
+	call	fib
+.L5:
+	j	.L5
+	.size	main, .-main
+	.ident	"GCC: (GNU) 10.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/tools/simkheiv/simkheiv.cpp
+++ b/tools/simkheiv/simkheiv.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
   std::string BaseNoExt = FileName.substr(0, FileName.find_last_of('.'));
   auto Files = std::ifstream(FileName);
   Simulator Sim(Files);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   Sim.dumpGPRegs();
 
   return 0;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -3,6 +3,7 @@ enable_testing()
 set(ALL_TESTS "")
 file(GLOB TEST_SOURCES *.cpp)
 include(GoogleTest)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/unittests)
 foreach(TEST_SRC ${TEST_SOURCES})
     
     get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)

--- a/unittests/SimulatorTest.cpp
+++ b/unittests/SimulatorTest.cpp
@@ -136,6 +136,7 @@ TEST(SimulatorTest, JALR) {
   };
 
   const GPRegisters EXPECTED = {{18, DRAM_BASE + 4}};
+  const Address EXPECTED_PC = 44;
   std::stringstream ss;
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
@@ -148,7 +149,169 @@ TEST(SimulatorTest, JALR) {
         << "Register:" << i << ", expected: " << EXPECTED[i]
         << ", got: " << Res[i];
   }
-  EXPECT_EQ(Sim.getPC(), 44)
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
       << "PC"
-      << ", expected: " << 44 << ", got: " << Sim.getPC();
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BEQ) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0x30, 0x00, // addi x16, x0, 3
+      0x93, 0x08, 0x30, 0x00, // addi x17, x0, 3
+      0x63, 0x16, 0x18, 0x01, // bne x16, x17, 12
+      0x63, 0x06, 0x18, 0x01, // beq x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, 3}, {17, 3}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BNE) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0x50, 0x00, // addi x16, x0, 5
+      0x93, 0x08, 0x30, 0x00, // addi x17, x0, 3
+      0x63, 0x06, 0x18, 0x01, // beq x16, x17, 12
+      0x63, 0x16, 0x18, 0x01, // bne x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, 5}, {17, 3}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BLT) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0xd0, 0xff, // addi x16, x0, -3
+      0x93, 0x08, 0x50, 0x00, // addi x17, x0, 5
+      0x63, 0x56, 0x18, 0x01, // bge x16, x17, 12
+      0x63, 0x46, 0x18, 0x01, // blt x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, -3}, {17, 5}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BGE) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0x60, 0x00, // addi x16, x0, 6
+      0x93, 0x08, 0x50, 0x00, // addi x17, x0, 5
+      0x63, 0x46, 0x18, 0x01, // blt x16, x17, 12
+      0x63, 0x56, 0x18, 0x01, // bge x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, 6}, {17, 5}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BLTU) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0x30, 0x00, // addi x16, x0, 3
+      0x93, 0x08, 0x50, 0x00, // addi x17, x0, 5
+      0x63, 0x76, 0x18, 0x01, // bgeu x16, x17, 12
+      0x63, 0x66, 0x18, 0x01, // bltu x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, 3}, {17, 5}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}
+
+TEST(SimulatorTest, BGEU) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0xd0, 0xff, // addi x16, x0, -3
+      0x93, 0x08, 0x50, 0x00, // addi x17, x0, 5
+      0x63, 0x66, 0x18, 0x01, // bltu x16, x17, 12
+      0x63, 0x76, 0x18, 0x01, // bgeu x16, x17, 12
+  };
+
+  const GPRegisters EXPECTED = {{16, -3}, {17, 5}};
+  const Address EXPECTED_PC = DRAM_BASE + 12 + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
 }

--- a/unittests/SimulatorTest.cpp
+++ b/unittests/SimulatorTest.cpp
@@ -86,6 +86,50 @@ TEST(SimulatorTest, XORI) {
   }
 }
 
+TEST(SimulatorTest, ADD) {
+  const unsigned char BYTES[] = {
+      0x93, 0x01, 0x50, 0x00, // addi x3, x0, 5
+      0x13, 0x02, 0x60, 0x00, // addi x4, x0, 6
+      0xb3, 0x82, 0x41, 0x00, // add x5, x3, x4
+  };
+
+  const GPRegisters EXPECTED = {{3, 5}, {4, 6}, {5, 11}};
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+}
+
+TEST(SimulatorTest, SUB) {
+  const unsigned char BYTES[] = {
+      0x93, 0x01, 0x50, 0x00, // addi x3, x0, 5
+      0x13, 0x02, 0x60, 0x00, // addi x4, x0, 6
+      0xb3, 0x82, 0x41, 0x40, // sub x2, x3, x4
+  };
+
+  const GPRegisters EXPECTED = {{3, 5}, {4, 6}, {5, -1}};
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+}
+
 TEST(SimulatorTest, AUIPC) {
   const unsigned char BYTES[] = {
       0x97, 0x08, 0x00, 0x00, // auipc x17, 0

--- a/unittests/SimulatorTest.cpp
+++ b/unittests/SimulatorTest.cpp
@@ -12,7 +12,7 @@ TEST(SimulatorTest, ADDI) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -32,7 +32,7 @@ TEST(SimulatorTest, SLTI) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -54,7 +54,7 @@ TEST(SimulatorTest, SLTIU) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -76,7 +76,7 @@ TEST(SimulatorTest, XORI) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -97,7 +97,7 @@ TEST(SimulatorTest, AUIPC) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -120,7 +120,7 @@ TEST(SimulatorTest, SWLW) {
   ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
 
   Simulator Sim(ss);
-  Sim.exec();
+  Sim.execFromDRAMBASE();
   GPRegisters &Res = Sim.getGPRegs();
 
   for (unsigned i = 0; i < 32; ++i) {
@@ -128,4 +128,27 @@ TEST(SimulatorTest, SWLW) {
         << "Register:" << i << ", expected: " << EXPECTED[i]
         << ", got: " << Res[i];
   }
+}
+
+TEST(SimulatorTest, JALR) {
+  const unsigned char BYTES[] = {
+      0x67, 0x09, 0xc0, 0x02, // jalr x18, x0, 44
+  };
+
+  const GPRegisters EXPECTED = {{18, DRAM_BASE + 4}};
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), 44)
+      << "PC"
+      << ", expected: " << 44 << ", got: " << Sim.getPC();
 }

--- a/unittests/SimulatorTest.cpp
+++ b/unittests/SimulatorTest.cpp
@@ -85,3 +85,47 @@ TEST(SimulatorTest, XORI) {
         << ", got: " << Res[i];
   }
 }
+
+TEST(SimulatorTest, AUIPC) {
+  const unsigned char BYTES[] = {
+      0x97, 0x08, 0x00, 0x00, // auipc x17, 0
+      0x17, 0x28, 0x00, 0x00, // auipc x16, 2
+  };
+
+  const GPRegisters EXPECTED = {{16, DRAM_BASE + 4 + 0x2000}, {17, DRAM_BASE}};
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.exec();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+}
+
+TEST(SimulatorTest, SWLW) {
+  const unsigned char BYTES[] = {
+      0x13, 0x08, 0x00, 0x80, // addi x16, x0, -2048
+      0x93, 0x08, 0x30, 0x00, // addi x17, x0, 3
+      0x23, 0x2e, 0x01, 0xff, // sw x16, -4(sp)
+      0x03, 0x29, 0xc1, 0xff, // lw x18, -4(sp)
+  };
+
+  const GPRegisters EXPECTED = {{16, -2048}, {17, 3}, {18, -2048}};
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.exec();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+}

--- a/unittests/SimulatorTest.cpp
+++ b/unittests/SimulatorTest.cpp
@@ -315,3 +315,27 @@ TEST(SimulatorTest, BGEU) {
       << "PC"
       << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
 }
+
+TEST(SimulatorTest, JAL) {
+  const unsigned char BYTES[] = {
+      0x6f, 0x09, 0xc0, 0x00, // jal x18, 12
+  };
+
+  const GPRegisters EXPECTED = {{18, DRAM_BASE + 4}};
+  const Address EXPECTED_PC = DRAM_BASE + 12;
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(BYTES), sizeof(BYTES));
+
+  Simulator Sim(ss);
+  Sim.execFromDRAMBASE();
+  GPRegisters &Res = Sim.getGPRegs();
+
+  for (unsigned i = 0; i < 32; ++i) {
+    EXPECT_EQ(Res[i], EXPECTED[i])
+        << "Register:" << i << ", expected: " << EXPECTED[i]
+        << ", got: " << Res[i];
+  }
+  EXPECT_EQ(Sim.getPC(), EXPECTED_PC)
+      << "PC"
+      << ", expected: " << EXPECTED_PC << ", got: " << Sim.getPC();
+}


### PR DESCRIPTION
Fixes #7
Fixes #6 

## Memory system

- address starts by 0x8000
- 1KiB, 
- stack pointer starts from 0x8000 + 1KiB
- [x] DRAM memory 


## I-type 

- [x] lw
- [x] jalr

## S-type

- [x] sw

## B-type

- [x] blt
- [x] bgt

## U-type

- [x] auipc

## J-type

- [x] jal



NOTE:
rvemu RV64 memory
- address starts by 0x80000000, 
- 1GiB, 
- stack pointer starts from 0x8000000 + 1GiB
